### PR TITLE
List not set Entry's Size field

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -155,6 +155,9 @@ func parseListLine(line string) (*Entry, error) {
 	}
 
 	e.Name = strings.Join(fields[8:], " ")
+	fileSize, _ := strconv.Atoi(fields[4])
+	e.Size = uint64(fileSize)
+
 	return e, nil
 }
 


### PR DESCRIPTION
I want to use List to get file size from ftp server, but I find List func not set Size field.

Btw, I tried a few go ftp client lib, your code works great, thank you.
