### PR TITLE
Changing expected status response for Logout call

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -437,7 +437,7 @@ func (c *ServerConn) NoOp() error {
 
 // Logout issues a REIN FTP command to logout the current user.
 func (c *ServerConn) Logout() error {
-	_, _, err := c.cmd(StatusLoggedIn, "REIN")
+	_, _, err := c.cmd(StatusReady, "REIN")
 	return err
 }
 


### PR DESCRIPTION
The REIN command returned a StatusReady(220), not StatusLoggedIn, so calling the existing Logout was producing an error for me. Thanks for taking a look!