### PR TITLE
Add a bool property for forcing Passive mode.

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -27,6 +27,7 @@ type ServerConn struct {
 	conn     *textproto.Conn
 	host     string
 	features map[string]string
+	Passive  bool
 }
 
 // Entry describes a file and is returned by List().
@@ -58,6 +59,7 @@ func Connect(addr string) (*ServerConn, error) {
 		conn:     conn,
 		host:     a[0],
 		features: make(map[string]string),
+		Passive:  false,
 	}
 
 	_, _, err = c.conn.ReadResponse(StatusReady)
@@ -203,7 +205,7 @@ func (c *ServerConn) openDataConn() (net.Conn, error) {
 	//  else -> PASV
 	_, nat6Supported := c.features["nat6"]
 	_, epsvSupported := c.features["EPSV"]
-	if nat6Supported || epsvSupported {
+	if !c.Passive && (nat6Supported || epsvSupported) {
 		port, err = c.epsv()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I ran into a scenario where Extended PASV mode was being used, but the the data connection would only work via PASV mode... can't say I'm familiar enough with FTP stuff to know my fix is the best solution, but this was an easy workaround in my case so thought I'd send it over.