### PR TITLE
Multi-line response support

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -251,7 +251,7 @@ func (c *ServerConn) cmdDataConn(format string, args ...interface{}) (net.Conn, 
 		return nil, err
 	}
 
-	code, msg, err := c.conn.ReadCodeLine(-1)
+	code, msg, err := c.conn.ReadResponse(-1)
 	if err != nil {
 		conn.Close()
 		return nil, err


### PR DESCRIPTION
I had an issue when FTP server returns multi-line response:

```
Accepted data connection
917.3 kbytes to download
```

The error is:
`unexpected multi-line response: Accepted data connection`
This pull-request fixes this issue
