### PR TITLE
Fix tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -109,7 +109,8 @@ func TestConn(t *testing.T) {
 	}
 
 	err = c.Logout()
-	if err != nil {
+	// REIN is not supported by vsftpd
+	if err != nil && err.Error() != "502 REIN not implemented." {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
Accept `502 REIN not implemented` as valid result for `Logout()` since there is no support in vsftpd.