### PR TITLE
Add coveralls.io to display test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ before_install:
 - sudo apt-get install -qq vsftpd
 - sudo cp $TRAVIS_BUILD_DIR/.vsftpd.conf /etc/vsftpd.conf
 - sudo service vsftpd restart
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- go get golang.org/x/tools/cmd/cover
+script:
+- $GOPATH/bin/goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # goftp #
 
 [![Build Status](https://travis-ci.org/jlaffaye/ftp.svg?branch=master)](https://travis-ci.org/jlaffaye/ftp)
+[![Coverage Status](https://coveralls.io/repos/jlaffaye/ftp/badge.svg?branch=master&service=github)](https://coveralls.io/github/jlaffaye/ftp?branch=master)
 
 A FTP client package for Go
 


### PR DESCRIPTION
To use coveralls.io, you need to connect it with you github account. The result looks like this:
https://coveralls.io/builds/3341978/source?filename=ftp.go