### PR TITLE
ServerConn::openDataConn() recursively tries to use EPSV and PASV.

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -217,28 +217,18 @@ func (c *ServerConn) pasv() (port int, err error) {
 
 // openDataConn creates a new FTP data connection.
 func (c *ServerConn) openDataConn() (net.Conn, error) {
-	var port int
-	var err error
+	var (
+		port int
+		err  error
+	)
 
-	//  If features contains nat6 or EPSV => EPSV
-	//  else -> PASV
-	_, nat6Supported := c.features["nat6"]
-	_, epsvSupported := c.features["EPSV"]
-
-	if !nat6Supported && !epsvSupported {
-		port, _ = c.pasv()
-	}
-	if port == 0 {
-		port, err = c.epsv()
-		if err != nil {
+	if port, err = c.epsv(); err != nil {
+		if port, err = c.pasv(); err != nil {
 			return nil, err
 		}
 	}
 
-	// Build the new net address string
-	addr := net.JoinHostPort(c.host, strconv.Itoa(port))
-
-	return net.DialTimeout("tcp", addr, c.timeout)
+	return net.DialTimeout("tcp", net.JoinHostPort(c.host, strconv.Itoa(port)), c.timeout)
 }
 
 // cmd is a helper function to execute a command and check for the expected FTP


### PR DESCRIPTION
I'm not an expert in FTP protocol, maybe there are some better workarounds. I've faced an issue with third-party ftp server: EPSV is in the feature list, but EPSV connection could not be established, and currently library doesn't try to fallback to PASV in that case, and I was unable to use it.

This PR makes ServerConn::openDataConn() not to rely on the feature list sent by server, but to try opening both EPSV and PASV, and only if both fails return the error.