### PR TITLE
RFC3659 improvements

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -332,6 +332,8 @@ func parseRFC3659ListLine(line string) (*Entry, error) {
 				e.Type = EntryTypeFolder
 			case "file":
 				e.Type = EntryTypeFile
+			case "OS.unix=symlink":
+				e.Type = EntryTypeLink
 			}
 		case "size":
 			e.setSize(value)

--- a/ftp.go
+++ b/ftp.go
@@ -325,7 +325,10 @@ func parseRFC3659ListLine(line string) (*Entry, error) {
 			}
 		case "type":
 			switch value {
-			case "dir", "cdir", "pdir":
+			case "cdir", "pdir":
+				// Discard current and parent dir
+				return nil, nil
+			case "dir":
 				e.Type = EntryTypeFolder
 			case "file":
 				e.Type = EntryTypeFile
@@ -541,7 +544,7 @@ func (c *ServerConn) List(path string) (entries []*Entry, err error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		entry, err := parseListLine(line)
-		if err == nil {
+		if err == nil && entry != nil {
 			entries = append(entries, entry)
 		}
 	}

--- a/ftp.go
+++ b/ftp.go
@@ -534,7 +534,20 @@ func (c *ServerConn) NameList(path string) (entries []string, err error) {
 
 // List issues a LIST FTP command.
 func (c *ServerConn) List(path string) (entries []*Entry, err error) {
-	conn, err := c.cmdDataConnFrom(0, "LIST %s", path)
+	var conn net.Conn
+
+	commands := []string{"MLSD", "LIST"}
+	if _, mlstSupported := c.features["MLST"]; !mlstSupported {
+		commands = commands[1:]
+	}
+
+	for _, cmd := range commands {
+		conn, err = c.cmdDataConnFrom(0, "%s %s", cmd, path)
+		if err == nil {
+			break
+		}
+	}
+
 	if err != nil {
 		return
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -42,8 +42,8 @@ var listTests = []line{
 	{"-rwxrwxrwx   1 noone    nogroup      322 Aug 19  1996 message.ftp", "message.ftp", 322, EntryTypeFile, time.Date(1996, time.August, 19, 0, 0, 0, 0, time.UTC)},
 
 	// RFC3659 format: https://tools.ietf.org/html/rfc3659#section-7
-	{"modify=20150813224845;perm=fle;type=cdir;unique=119FBB87U4;UNIX.group=0;UNIX.mode=0755;UNIX.owner=0; .", ".", 0, EntryTypeFolder, time.Date(2015, time.August, 13, 22, 48, 45, 0, time.UTC)},
-	{"modify=20150813224845;perm=fle;type=pdir;unique=119FBB87U4;UNIX.group=0;UNIX.mode=0755;UNIX.owner=0; ..", "..", 0, EntryTypeFolder, time.Date(2015, time.August, 13, 22, 48, 45, 0, time.UTC)},
+	{"modify=20150813224845;perm=fle;type=cdir;unique=119FBB87U4;UNIX.group=0;UNIX.mode=0755;UNIX.owner=0; .", "", 0, 0, time.Now()},
+	{"modify=20150813224845;perm=fle;type=pdir;unique=119FBB87U4;UNIX.group=0;UNIX.mode=0755;UNIX.owner=0; ..", "", 0, 0, time.Now()},
 	{"modify=20150806235817;perm=fle;type=dir;unique=1B20F360U4;UNIX.group=0;UNIX.mode=0755;UNIX.owner=0; movies", "movies", 0, EntryTypeFolder, time.Date(2015, time.August, 6, 23, 58, 17, 0, time.UTC)},
 	{"modify=20150814172949;perm=flcdmpe;type=dir;unique=85A0C168U4;UNIX.group=0;UNIX.mode=0777;UNIX.owner=0; _upload", "_upload", 0, EntryTypeFolder, time.Date(2015, time.August, 14, 17, 29, 49, 0, time.UTC)},
 	{"modify=20150813175250;perm=adfr;size=951;type=file;unique=119FBB87UE;UNIX.group=0;UNIX.mode=0644;UNIX.owner=0; welcome.msg", "welcome.msg", 951, EntryTypeFile, time.Date(2015, time.August, 13, 17, 52, 50, 0, time.UTC)},
@@ -73,6 +73,12 @@ func TestParseValidListLine(t *testing.T) {
 		entry, err := parseListLine(lt.line)
 		if err != nil {
 			t.Errorf("parseListLine(%v) returned err = %v", lt.line, err)
+			continue
+		}
+		if lt.name == "" {
+			if entry != nil {
+				t.Errorf("parseListLine(%v) must not be returned", lt.line)
+			}
 			continue
 		}
 		if entry.Name != lt.name {


### PR DESCRIPTION
Hi,

For one of my own project I needed a precise last modification time (which cannot be given by the traditional LIST command) so I added the support for the MLSD command (RFC3659) which is used transparently, when available, within the standard list() function.

This PR also fixes a bug caused by the cdir/pdir types and added support for symbolic links as well.
