### PR TITLE
Make ServerConn safe for concurrent use

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ go get -u github.com/jlaffaye/ftp
 ## Documentation ##
 
 http://godoc.org/github.com/jlaffaye/ftp
+
+## Concurrency Notes ##
+
+`ServerConn` is safe for concurrent access. What this means in practice is that
+you can dial a connection to your FTP server, login, and pass around the
+resulting `ServerConn` to multiple goroutines. However, this does not mean that
+you can simultaneously upload or download multiple files. Because of limitations
+inherent to the FTP protocol, there is a lock around these kinds of methods. The
+user also needs to be aware that any call to `ChangeDir()` or similar will be
+felt across every goroutine accessing that session. It is best to handle those
+calls synchronously, eg immediately after logging into the FTP server.


### PR DESCRIPTION
ServerConn's textproto.Conn is safe for concurrent access. This adds
calls to StartResponse() and EndResponse() to put that to use wherever
Cmd() is called.
https://golang.org/pkg/net/textproto/#Conn.Cmd

Additionally, this adds a sync.Mutex on ServerConn to provide
concurrency protection for data commands such as STOR and RETR that need
to run through synchronous steps.
