### PR TITLE
Fix ls bug for file or folder name includes multiple spaces

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -325,6 +325,22 @@ func parseRFC3659ListLine(line string) (*Entry, error) {
 	return e, nil
 }
 
+// parse file or folder name with multiple spaces
+func parseLsListLineName(line string, fields []string, offset int) string {
+	if offset < 1 {
+		return ""
+	}
+
+	match := fields[offset-1]
+	index := strings.Index(line, match)
+	if index == -1 {
+		return ""
+	}
+
+	index += len(match)
+	return strings.TrimSpace(line[index:])
+}
+
 // parseLsListLine parses a directory line in a format based on the output of
 // the UNIX ls command.
 func parseLsListLine(line string) (*Entry, error) {
@@ -384,7 +400,11 @@ func parseLsListLine(line string) (*Entry, error) {
 		return nil, err
 	}
 
-	e.Name = strings.Join(fields[8:], " ")
+	e.Name = parseLsListLineName(line, fields, 8)
+	if len(e.Name) == 0 {
+		e.Name = strings.Join(fields[8:], " ")
+	}
+
 	return e, nil
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -49,6 +49,10 @@ var listTests = []line{
 	// DOS DIR command output
 	{"08-07-15  07:50PM                  718 Post_PRR_20150901_1166_265118_13049.dat", "Post_PRR_20150901_1166_265118_13049.dat", 718, EntryTypeFile, time.Date(2015, time.August, 7, 19, 50, 0, 0, time.UTC)},
 	{"08-10-15  02:04PM       <DIR>          Billing", "Billing", 0, EntryTypeFolder, time.Date(2015, time.August, 10, 14, 4, 0, 0, time.UTC)},
+
+	// dir and file names that contain multiple spaces
+	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 spaces   dir   name", "spaces   dir   name", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
+	{"-rwxr-xr-x    3 110      1002            1234567 Dec 02  2009 file   name", "file   name", 1234567, EntryTypeFile, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 }
 
 // Not supported, we expect a specific error message


### PR DESCRIPTION
The result of strings.Join(fields[8:], " ") is wrong if file name includes multiple spaces. We must get file name from original list line.
