### PR TITLE
Fix incorrect filename parsing

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -4,6 +4,7 @@ package ftp
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/textproto"
@@ -342,7 +343,7 @@ func parseLsListLineName(line string, fields []string, offset int) string {
 		return ""
 	}
 
-	match := fields[offset-1]
+	match := fmt.Sprintf(" %s ", fields[offset-1])
 	index := strings.Index(line, match)
 	if index == -1 {
 		return ""

--- a/parse_test.go
+++ b/parse_test.go
@@ -24,6 +24,8 @@ var listTests = []line{
 	// UNIX ls -l style
 	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 pub", "pub", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 p u b", "p u b", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
+	{"-rw-r--r--   1 marketwired marketwired    12016 Mar 16  2016 2016031611G087802-001.newsml", "2016031611G087802-001.newsml", 12016, EntryTypeFile, time.Date(2016, time.March, 16, 0, 0, 0, 0, time.UTC)},
+
 	{"-rwxr-xr-x    3 110      1002            1234567 Dec 02  2009 fileName", "fileName", 1234567, EntryTypeFile, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"lrwxrwxrwx   1 root     other          7 Jan 25 00:17 bin -> usr/bin", "bin -> usr/bin", 0, EntryTypeLink, time.Date(thisYear, time.January, 25, 0, 17, 0, 0, time.UTC)},
 


### PR DESCRIPTION
When the file creation year, file size and filename contains the same substring the parsed filename should contains only the correct filename.

In the example below you can see the parsing fails in that case:

```
-rw-r--r--   1 marketwired marketwired    12016 Mar 16  2016 2016031611G087802-001.newsml
```