### PR TITLE
Fix whitespace handling before, after or inside a filename

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -340,7 +340,7 @@ func parseRFC3659ListLine(line string) (*Entry, error) {
 // parse file or folder name with starting or containing multiple whitespaces
 func fieldsLsList(s string) []string {
 	n := 8
-	fields := make([]string, 0, n)
+	fields := make([]string, 0, n+1)
 	fieldStart := -1
 	nextbreak := false
 	for i, c := range s {

--- a/parse_test.go
+++ b/parse_test.go
@@ -25,6 +25,8 @@ var listTests = []line{
 	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 pub", "pub", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 p u b", "p u b", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"-rw-r--r--   1 marketwired marketwired    12016 Mar 16  2016 2016031611G087802-001.newsml", "2016031611G087802-001.newsml", 12016, EntryTypeFile, time.Date(2016, time.March, 16, 0, 0, 0, 0, time.UTC)},
+	{"-rw-r--r--   1 marketwired marketwired    2016 Mar 16  2016 2016031611G087802-001.newsml", "2016031611G087802-001.newsml", 2016, EntryTypeFile, time.Date(2016, time.March, 16, 0, 0, 0, 0, time.UTC)},
+	{"-rw-r--r--   1 marketwired marketwired    12016 Mar 16  2016  2016031611G087802-001.newsml ", " 2016031611G087802-001.newsml ", 12016, EntryTypeFile, time.Date(2016, time.March, 16, 0, 0, 0, 0, time.UTC)},
 
 	{"-rwxr-xr-x    3 110      1002            1234567 Dec 02  2009 fileName", "fileName", 1234567, EntryTypeFile, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"lrwxrwxrwx   1 root     other          7 Jan 25 00:17 bin -> usr/bin", "bin -> usr/bin", 0, EntryTypeLink, time.Date(thisYear, time.January, 25, 0, 17, 0, 0, time.UTC)},


### PR DESCRIPTION
The commit 08566066b1d26c3d0a3b816487082e91ca309fdd from @svett works on:

> -rw-r--r--   1 marketwired marketwired    **12016** Mar 16  2016 2016031611G087802-001.newsml", "2016031611G087802-001.newsml

but breaks if the file size is the same as the year:

> -rw-r--r--   1 marketwired marketwired    **2016** Mar 16  2016 2016031611G087802-001.newsml", "2016031611G087802-001.newsml

I've also noticed that the current code doesn't support file names starting with a space and lacked some tests, that this pull request tries to address.