### PR TITLE
Avoid forever lock

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -81,6 +81,7 @@ func testConn(t *testing.T, disableEPSV bool) {
 			t.Errorf("'%s'", buf)
 		}
 		r.Close()
+		r.Close() // test we can close two times
 	}
 
 	// Read with deadline

--- a/ftp.go
+++ b/ftp.go
@@ -338,7 +338,7 @@ func (c *ServerConn) NameList(path string) (entries []string, err error) {
 		return
 	}
 
-	r := &Response{conn, c, false}
+	r := &Response{conn: conn, c: c}
 	defer r.Close()
 
 	scanner := bufio.NewScanner(r)
@@ -369,7 +369,7 @@ func (c *ServerConn) List(path string) (entries []*Entry, err error) {
 		return
 	}
 
-	r := &Response{conn, c, false}
+	r := &Response{conn: conn, c: c}
 	defer r.Close()
 
 	scanner := bufio.NewScanner(r)
@@ -446,7 +446,7 @@ func (c *ServerConn) RetrFrom(path string, offset uint64) (*Response, error) {
 		return nil, err
 	}
 
-	return &Response{conn, c, false}, nil
+	return &Response{conn: conn, c: c}, nil
 }
 
 // Stor issues a STOR FTP command to store a file to the remote FTP server.
@@ -538,7 +538,7 @@ func (r *Response) Read(buf []byte) (int, error) {
 
 // Close implements the io.Closer interface on a FTP data connection.
 func (r *Response) Close() error {
-	if r.connClosed == true {
+	if r.connClosed {
 		return nil
 	}
 	err := r.conn.Close()

--- a/ftp.go
+++ b/ftp.go
@@ -537,6 +537,7 @@ func (r *Response) Read(buf []byte) (int, error) {
 }
 
 // Close implements the io.Closer interface on a FTP data connection.
+// After the first call, Close will do nothing and return nil.
 func (r *Response) Close() error {
 	if r.closed {
 		return nil

--- a/ftp.go
+++ b/ftp.go
@@ -47,9 +47,9 @@ type Entry struct {
 
 // Response represents a data-connection
 type Response struct {
-	conn       net.Conn
-	c          *ServerConn
-	connClosed bool
+	conn   net.Conn
+	c      *ServerConn
+	closed bool
 }
 
 // Connect is an alias to Dial, for backward compatibility
@@ -538,7 +538,7 @@ func (r *Response) Read(buf []byte) (int, error) {
 
 // Close implements the io.Closer interface on a FTP data connection.
 func (r *Response) Close() error {
-	if r.connClosed {
+	if r.closed {
 		return nil
 	}
 	err := r.conn.Close()
@@ -546,7 +546,7 @@ func (r *Response) Close() error {
 	if err2 != nil {
 		err = err2
 	}
-	r.connClosed = true
+	r.closed = true
 	return err
 }
 


### PR DESCRIPTION
If we close the connection two times the second time will hang forever waiting for a server code.