### PR TITLE
Moving the set UTF-8 and binary modes out of the login method

### DIFF
--- a/client_multiline_test.go
+++ b/client_multiline_test.go
@@ -94,6 +94,14 @@ func TestMultiline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = c.Binary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetUTF8()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	c.Quit()
 

--- a/client_test.go
+++ b/client_test.go
@@ -42,6 +42,16 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Fatal(err)
 	}
 
+	err = c.Binary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SetUTF8()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = c.NoOp()
 	if err != nil {
 		t.Error(err)
@@ -214,6 +224,16 @@ func TestConnIPv6(t *testing.T) {
 	}
 
 	err = c.Login("anonymous", "anonymous")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Binary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SetUTF8()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ftp.go
+++ b/ftp.go
@@ -128,17 +128,14 @@ func (c *ServerConn) Login(user, password string) error {
 	default:
 		return errors.New(message)
 	}
+	return nil
+}
 
+func (c *ServerConn) Binary() error {
 	// Switch to binary mode
-	if _, _, err = c.cmd(StatusCommandOK, "TYPE I"); err != nil {
+	if _, _, err := c.cmd(StatusCommandOK, "TYPE I"); err != nil {
 		return err
 	}
-
-	// Switch to UTF-8
-	if err := c.setUTF8(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -179,8 +176,8 @@ func (c *ServerConn) feat() error {
 	return nil
 }
 
-// setUTF8 issues an "OPTS UTF8 ON" command.
-func (c *ServerConn) setUTF8() error {
+// SetUTF8 issues an "OPTS UTF8 ON" command.
+func (c *ServerConn) SetUTF8() error {
 	if _, ok := c.features["UTF8"]; !ok {
 		return nil
 	}


### PR DESCRIPTION
Fix for #89