### PR TITLE
Add a case to catch Unix-like but 0 link count list line

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -13,6 +13,7 @@ var listLineParsers = []func(line string) (*Entry, error){
 	parseRFC3659ListLine,
 	parseLsListLine,
 	parseDirListLine,
+	parseHostedFTPLine,
 }
 
 var dirTimeFormats = []string{
@@ -99,7 +100,7 @@ func parseLsListLine(line string) (*Entry, error) {
 		}
 
 		if err := e.setSize(fields[2]); err != nil {
-			return nil, err
+			return nil, errUnsupportedListLine
 		}
 		if err := e.setTime(fields[4:7]); err != nil {
 			return nil, err
@@ -178,6 +179,27 @@ func parseDirListLine(line string) (*Entry, error) {
 
 	e.Name = strings.TrimLeft(line, " ")
 	return e, nil
+}
+
+// parseHostedFTPLine parses a directory line in the non-standard format used
+// by hostedftp.com
+// -r--------   0 user group     65222236 Feb 24 00:39 UABlacklistingWeek8.csv
+// (The link count is inexplicably 0)
+func parseHostedFTPLine(line string) (*Entry, error) {
+	// Has the first field a length of 10 bytes?
+	if strings.IndexByte(line, ' ') != 10 {
+		return nil, errUnsupportedListLine
+	}
+
+	scanner := newScanner(line)
+	fields := scanner.NextFields(9)
+	if fields[1] == "0" { // Set link count to 1 and attempt to parse as Unix.
+		fields[1] = "1"
+		newLine := strings.Join(fields, " ")
+		return parseLsListLine(newLine)
+	}
+	return nil, errUnsupportedListLine
+
 }
 
 // parseListLine parses the various non-standard format returned by the LIST

--- a/parse_test.go
+++ b/parse_test.go
@@ -56,6 +56,9 @@ var listTests = []line{
 	{"drwxr-xr-x    3 110      1002            3 Dec 02  2009 spaces   dir   name", "spaces   dir   name", 0, EntryTypeFolder, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"-rwxr-xr-x    3 110      1002            1234567 Dec 02  2009 file   name", "file   name", 1234567, EntryTypeFile, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
 	{"-rwxr-xr-x    3 110      1002            1234567 Dec 02  2009  foo bar ", " foo bar ", 1234567, EntryTypeFile, time.Date(2009, time.December, 2, 0, 0, 0, 0, time.UTC)},
+
+	// Odd link count from hostedftp.com
+	{"-r--------   0 user group     65222236 Feb 24 00:39 RegularFile", "RegularFile", 65222236, EntryTypeFile, time.Date(thisYear, time.February, 24, 0, 39, 0, 0, time.UTC)},
 }
 
 // Not supported, we expect a specific error message


### PR DESCRIPTION
This happened with one provider (hostedftp.com). Let me know if there's a better way to approach this problem.