### PR TITLE
add clnt option

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,7 +22,11 @@ func TestConnEPSV(t *testing.T) {
 	testConn(t, false)
 }
 
-func testConn(t *testing.T, disableEPSV bool) {
+func TestConnWithCLNT(t *testing.T) {
+	testConn(t, true, true)
+}
+
+func testConn(t *testing.T, disableEPSV bool, CLNTOption ...bool) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -35,6 +39,10 @@ func testConn(t *testing.T, disableEPSV bool) {
 	if disableEPSV {
 		delete(c.features, "EPSV")
 		c.DisableEPSV = true
+	}
+
+	if len(CLNTOption) > 0 {
+		c.CLNTCommand = true
 	}
 
 	err = c.Login("anonymous", "anonymous")

--- a/ftp.go
+++ b/ftp.go
@@ -30,6 +30,10 @@ type ServerConn struct {
 	// Do not use EPSV mode
 	DisableEPSV bool
 
+	// CLNTCommand Option [The CLNT command is used to identify the client software to the server.
+	// This command serves no functional purpose other than to provide information to the server.]
+	CLNTCommand bool
+
 	conn          *textproto.Conn
 	host          string
 	timeout       time.Duration
@@ -127,6 +131,12 @@ func (c *ServerConn) Login(user, password string) error {
 		}
 	default:
 		return errors.New(message)
+	}
+
+	if c.CLNTCommand {
+		if _, _, err = c.cmd(StatusCommandOK, "CLNT"); err != nil {
+			return err
+		}
 	}
 
 	// Switch to binary mode


### PR DESCRIPTION
Hello

According to `Serv-U` FTP Options , The CLNT command is used to identify the client software to the server. This command serves no functional purpose other than to provide information to the server.

So , For enable it , we can use :

```go
...
        c, err := ftp.Connect(FTP_SERVER)
	if err != nil {
		return err
	}

	c.CLNTCommand = true

	err = c.Login(FTP_USER, FTP_PASS)
	if err != nil {
		return err
	}
...
```