### PR TITLE
Implement STARTTLS (explicit TLS) support

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -23,8 +23,9 @@ type ftpMock struct {
 	sync.WaitGroup
 }
 
-// newFtpMock returns a mock implementation of a FTP server
-// For simplication, a mock instance only accepts a signle connection and terminates afer
+// newFtpMock returns a mock implementation of a FTP server.
+//
+// To simplify, a mock instance only accepts a single connection and terminates afterwards.
 func newFtpMock(t *testing.T, address string) (*ftpMock, error) {
 	var err error
 	mock := &ftpMock{address: address}


### PR DESCRIPTION
Hi,

I have added simple support for STARTTLS. It is a very basic implementation that probably only works in a few usecases, for mine it works fine.

Please tell me what I should extend / improve to get this merged upstream.

Thanks.