### PR TITLE
Update Go version in Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 dist: trusty
 sudo: required
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
 env:
   - FTP_SERVER=vsftpd
   - FTP_SERVER=proftpd

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -15,4 +15,5 @@ esac
 
 mkdir --mode 0777 -p /var/ftp/incoming
 
+apt-get update -qq
 apt-get install -qq "$1"


### PR DESCRIPTION
This updates the Go version used in the Travis build. I also added a `apt-get update`  again to see if the `vsftpd` build flavor starts working again.