### PR TITLE
Implements DialWithDialer to be used with a SOCKS5 proxy

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -82,7 +82,7 @@ func DialTimeout(addr string, timeout time.Duration) (*ServerConn, error) {
 }
 
 // DialWithDialer initializes the connection with the specified dialer at the specified addr
-// The providen Dialer can be a proxy
+// The Dialer can be a proxy
 func DialWithDialer(dialer Dialer, addr string, timeout time.Duration) (*ServerConn, error) {
 	tconn, err := dialer.Dial("tcp", addr)
 	if err != nil {

--- a/ftp.go
+++ b/ftp.go
@@ -24,6 +24,7 @@ const (
 	EntryTypeLink
 )
 
+// A Dialer is a means to establish a connection.
 type Dialer interface {
 	// Dial connects to the given address.
 	Dial(network, addr string) (c net.Conn, err error)


### PR DESCRIPTION
This PR implements ftp.DialWithDialer to use ftp with a SOCKS5 proxy.

Here is how to use it with a proxy:

```golang
func connect() error {
	dialer, err := proxy.SOCKS5("tcp",
		ProxyHost+":"+ProxyPort,
		&proxy.Auth{
			User:     ProxyUser,
			Password: ProxyPass,
		},
		proxy.Direct)
	if err != nil {
		log.Fatal("Failed to create SOCKS5 dialer")
	}

	conn, err := ftp.DialWithDialer(dialer, FTPHost, 20*time.Second)
	if err != nil {
		log.Fatal("FTP DialWithDialer failed", err)
	}
}
```