### PR TITLE
Don't set the UTF8 and Binary options in Login

### DIFF
--- a/client_multiline_test.go
+++ b/client_multiline_test.go
@@ -94,6 +94,38 @@ func TestMultiline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIITelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIIASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICTelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetUTF8()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	c.Quit()
 

--- a/client_multiline_test.go
+++ b/client_multiline_test.go
@@ -112,7 +112,7 @@ func TestMultiline(t *testing.T) {
 	// Wait for the connection to close
 	mock.Wait()
 
-	expected := []string{"FEAT", "USER", "PASS", "TYPE", "TYPE", "TYPE", "QUIT"}
+	expected := []string{"FEAT", "USER", "PASS", "TYPE", "TYPE", "QUIT"}
 	if !reflect.DeepEqual(mock.commands, expected) {
 		t.Fatal("unexpected sequence of commands:", mock.commands, "expected:", expected)
 	}

--- a/client_multiline_test.go
+++ b/client_multiline_test.go
@@ -98,10 +98,6 @@ func TestMultiline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeEBCDIC)
-	if err != nil {
-		t.Fatal(err)
-	}
 	err = c.SetTransferType(TransferTypeBinary)
 	if err != nil {
 		t.Fatal(err)

--- a/client_multiline_test.go
+++ b/client_multiline_test.go
@@ -94,27 +94,11 @@ func TestMultiline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	err = c.SetTransferType(TransferTypeASCII)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeASCIITelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeASCIIASA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICTelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICASA)
+	err = c.SetTransferType(TransferTypeEBCDIC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +116,7 @@ func TestMultiline(t *testing.T) {
 	// Wait for the connection to close
 	mock.Wait()
 
-	expected := []string{"FEAT", "USER", "PASS", "TYPE", "QUIT"}
+	expected := []string{"FEAT", "USER", "PASS", "TYPE", "TYPE", "TYPE", "QUIT"}
 	if !reflect.DeepEqual(mock.commands, expected) {
 		t.Fatal("unexpected sequence of commands:", mock.commands, "expected:", expected)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -42,27 +42,11 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Fatal(err)
 	}
 
-	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	err = c.SetTransferType(TransferTypeASCII)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeASCIITelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeASCIIASA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICTelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICASA)
+	err = c.SetTransferType(TransferTypeEBCDIC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,27 +236,11 @@ func TestConnIPv6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	err = c.SetTransferType(TransferTypeASCII)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeASCIITelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeASCIIASA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICTelnet)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDICASA)
+	err = c.SetTransferType(TransferTypeEBCDIC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -42,6 +42,40 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Fatal(err)
 	}
 
+	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIITelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIIASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICTelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SetUTF8()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = c.NoOp()
 	if err != nil {
 		t.Error(err)
@@ -214,6 +248,40 @@ func TestConnIPv6(t *testing.T) {
 	}
 
 	err = c.Login("anonymous", "anonymous")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SetTransferType(TransferTypeASCIINonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIITelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeASCIIASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICNonPrint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICTelnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeEBCDICASA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.SetTransferType(TransferTypeBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.SetUTF8()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -46,10 +46,6 @@ func testConn(t *testing.T, disableEPSV bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c.SetTransferType(TransferTypeEBCDIC)
-	if err != nil {
-		t.Fatal(err)
-	}
 	err = c.SetTransferType(TransferTypeBinary)
 	if err != nil {
 		t.Fatal(err)
@@ -237,10 +233,6 @@ func TestConnIPv6(t *testing.T) {
 	}
 
 	err = c.SetTransferType(TransferTypeASCII)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.SetTransferType(TransferTypeEBCDIC)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ftp.go
+++ b/ftp.go
@@ -26,13 +26,9 @@ const (
 
 // The different types of files to transfer
 const (
-	TransferTypeASCIINonPrint  = "TYPE A N"
-	TransferTypeASCIITelnet    = "TYPE A T"
-	TransferTypeASCIIASA       = "TYPE A C"
-	TransferTypeEBCDICNonPrint = "TYPE E N"
-	TransferTypeEBCDICTelnet   = "TYPE E T"
-	TransferTypeEBCDICASA      = "TYPE E C"
-	TransferTypeBinary         = "TYPE I"
+	TransferTypeASCII  = "TYPE A"
+	TransferTypeEBCDIC = "TYPE E"
+	TransferTypeBinary = "TYPE I"
 	// TransferTypeLocalFormat is left out because it requires an arbitrary second
 	// argument specifying the number of bits per byte on the local system
 )
@@ -151,10 +147,6 @@ func (c *ServerConn) Login(user, password string) error {
 //		E - EBCDIC text
 //		I - image (binary data)
 //		L - local format
-// For A and E, the second type character specifies how the text should be interpreted:
-//		N - Non-print (not destined for printing). Default, if second-type-character is omitted.
-//		T - Telnet format control (<CR>, <FF>, etc.)
-//		C - ASA Carriage Control
 // For L, the second-type-character specifies the number of bits per byte on
 // the local system, and may not be omitted
 func (c *ServerConn) SetTransferType(transferType string) error {

--- a/ftp.go
+++ b/ftp.go
@@ -27,7 +27,6 @@ const (
 // The different types of files to transfer
 const (
 	TransferTypeASCII  = "TYPE A"
-	TransferTypeEBCDIC = "TYPE E"
 	TransferTypeBinary = "TYPE I"
 	// TransferTypeLocalFormat is left out because it requires an arbitrary second
 	// argument specifying the number of bits per byte on the local system
@@ -144,7 +143,6 @@ func (c *ServerConn) Login(user, password string) error {
 //
 // Accepts "TYPE <type-character> [<second-type-character>]", where type character can be one of:
 //		A - ASCII text
-//		E - EBCDIC text
 //		I - image (binary data)
 //		L - local format
 // For L, the second-type-character specifies the number of bits per byte on

--- a/ftp.go
+++ b/ftp.go
@@ -166,7 +166,7 @@ func (c *ServerConn) SetTransferType(transferType string) error {
 // SetUTF8 sets UTF-8 encoding when exchanging pathnames
 func (c *ServerConn) SetUTF8() error {
 	// Switch to UTF-8
-	err = c.setUTF8()
+	err := c.setUTF8()
 	return err
 }
 


### PR DESCRIPTION
This removes two steps of the Login function: setting the binary file transfer mode, and setting the UTF8 encoded filename exchange option. As mentioned in #89, I think these options should be left to the client to set rather than forced upon login. If a server doesn't support the `OPTS` command, defined in [RFC 2389](https://tools.ietf.org/html/rfc2389), then the login function will return an error due to trying to set the UTF8 option. 

Lots of this comes from the old PR #90, which seemed to be abandoned. I also tried to follow @jlaffaye's advice with regards to the `SetTransferType` method, but I actually didn't implement the transfer type as an Enum since the "local format" type allows an arbitrary number to indicate how many bits comprise a byte on that system. I kept the `transferType` parameter as a string.