### PR TITLE
Update ftp.go

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -307,7 +307,7 @@ func (c *ServerConn) feat() error {
 
 // setUTF8 issues an "OPTS UTF8 ON" command.
 func (c *ServerConn) setUTF8() error {
-	if _, ok := c.features["UTF8"]; !ok {
+	if _, ok := c.features["UTF8"]; ok {
 		return nil
 	}
 


### PR DESCRIPTION
修改key判断，存在UTF8代表默认UTF8编码，就不需要执行OPTS UTF8 ON切换了。
在pure-ftpd v1.0.49版本中OPTS UTF8 ON无法使用。需要使用pure-ftpd v1.0.47版本。

#

Modify the key judgment, the existence of UTF8 represents the default UTF8 encoding, there is no need to perform OPTS UTF8 ON switch.
OPTS UTF8 ON is not available in pure-ftpd v1.0.49.Pure-ftpd v1.0.47 version is required.