### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 before_install:
 - sudo sysctl net.ipv6.conf.lo.disable_ipv6=0
 - go get github.com/mattn/goveralls
-- go get github.com/golang/lint/golint
+- go get golang.org/x/lint/golint
 script:
 - goveralls -v
 - golint -set_exit_status $(go list ./...)


### PR DESCRIPTION
I noticed the Travis build is failing because it is trying to pull in golint using the wrong path. This fixes the build by correcting the path.

Additionally I think there is something wrong with the integration between Travis and Github for this repository as only the build status for coveralls shows up but not for Travis itself.