### PR TITLE
EntryType String() function

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -810,3 +810,8 @@ func (r *Response) Close() error {
 func (r *Response) SetDeadline(t time.Time) error {
 	return r.conn.SetDeadline(t)
 }
+
+// String returns the string representation of EntryType t.
+func (t EntryType) String() string {
+	return [...]string{"file", "folder", "link"}[t]
+}


### PR DESCRIPTION
This PR adds a `String()` function to the EntryType struct. `String()` returns the string representation of EntryType t.

Example:
```golang
// ...
w := conn.Walk("/")
for w.Next() {
    fmt.Println(w.Stat().Type.String()) // => file, folder or link
}
```