### PR TITLE
Workaround pure-ftpd connections failing with "Unknown command"

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -346,7 +346,7 @@ func (c *ServerConn) setUTF8() error {
 	}
 
 	// Workaround for FTP servers, that does not support this option.
-	if code == StatusBadArguments {
+	if code == StatusBadArguments || code == StatusNotImplementedParameter {
 		return nil
 	}
 


### PR DESCRIPTION
pure-ftpd 1.0.49-4 as supplied as part of Ubuntu 20.04 advertises UTF8
support in the FEAT command but the OPTS command fails to turn it on.

    OPTS UTF8 ON
    504 Unknown command

This patch introduces a workaround to ignore the error which enables
this library to work with this version of pure-ftpd. Filezilla appears
to ignore this error in a similar way.