### PR TITLE
allow to send custom command

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -180,6 +180,17 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Error(err)
 	}
 
+	code, response, err := c.SendCustomCommand("NOOP")
+	if err != nil {
+		t.Error(err)
+	}
+	if code != StatusCommandOK {
+		t.Errorf("Unexpected status code, got %v, want %v", code, StatusCommandOK)
+	}
+	if response != "NOOP ok." {
+		t.Errorf("Unexpected custom command response %#v", response)
+	}
+
 	err = c.Logout()
 	if err != nil {
 		if protoErr := err.(*textproto.Error); protoErr != nil {

--- a/ftp.go
+++ b/ftp.go
@@ -773,6 +773,12 @@ func (c *ServerConn) NoOp() error {
 	return err
 }
 
+// SendCustomCommand issues a user specified command.
+// Returns the status code, the server response and an error if any.
+func (c *ServerConn) SendCustomCommand(command string) (int, string, error) {
+	return c.cmd(0, command)
+}
+
 // Logout issues a REIN FTP command to logout the current user.
 func (c *ServerConn) Logout() error {
 	_, _, err := c.cmd(StatusReady, "REIN")


### PR DESCRIPTION
I use this patch in my test cases, for example:

```
code, response, err := client.SendCustomCommand(fmt.Sprintf("MFMT %v %v", mtime, testFileName))
assert.NoError(t, err)
assert.Equal(t, ftp.StatusFile, code)
assert.Equal(t, fmt.Sprintf("Modify=%v; %v", mtime, testFileName), response)
```

or 

```
code, response, err := client.SendCustomCommand(fmt.Sprintf("SITE CHMOD 600 %v", testFileName))
assert.NoError(t, err)
assert.Equal(t, ftp.StatusCommandOK, code)
assert.Equal(t, "SITE CHMOD command successful", response)
```