### PR TITLE
Fix Stor() no longer reporting errors from the io.Reader passed in

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -663,10 +663,13 @@ func (c *ServerConn) StorFrom(path string, r io.Reader, offset uint64) error {
 	// the response and we cannot use the connection to send other commands.
 	// So we don't check io.Copy error and we return the error from
 	// ReadResponse so the user can see the real error
-	io.Copy(conn, r)
+	_, err = io.Copy(conn, r)
 	conn.Close()
 
-	_, _, err = c.conn.ReadResponse(StatusClosingDataConnection)
+	_, _, respErr := c.conn.ReadResponse(StatusClosingDataConnection)
+	if respErr != nil {
+		err = respErr
+	}
 	return err
 }
 
@@ -682,10 +685,13 @@ func (c *ServerConn) Append(path string, r io.Reader) error {
 	}
 
 	// see the comment for StorFrom above
-	io.Copy(conn, r)
+	_, err = io.Copy(conn, r)
 	conn.Close()
 
-	_, _, err = c.conn.ReadResponse(StatusClosingDataConnection)
+	_, _, respErr := c.conn.ReadResponse(StatusClosingDataConnection)
+	if respErr != nil {
+		err = respErr
+	}
 	return err
 }
 


### PR DESCRIPTION
This commit

4a68979b896a741e always return the ReadResponse error after an upload

Broke the error return from Stor().  If you attempt to upload a file
with Stor() and the io.Reader that you passed in returns an error,
this was not returned by the Stor() command leading the user to think
the file was uploaded correctly.

This was detected by rclone's unit tests and the exact commit was
pinpointed with git commit.

This commit fixes it by returning the error from io.Copy or the error
from ReadResponse - the latter if they are both set.

Fixes #198