### PR TITLE
Delay FEAT command until after Login - fixes #200

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -135,16 +135,6 @@ func Dial(addr string, options ...DialOption) (*ServerConn, error) {
 		c.conn = textproto.NewConn(do.wrapConn(tconn))
 	}
 
-	err = c.feat()
-	if err != nil {
-		c.Quit()
-		return nil, err
-	}
-
-	if _, mlstSupported := c.features["MLST"]; mlstSupported {
-		c.mlstSupported = true
-	}
-
 	return c, nil
 }
 
@@ -280,6 +270,15 @@ func (c *ServerConn) Login(user, password string) error {
 		}
 	default:
 		return errors.New(message)
+	}
+
+	// Probe features
+	err = c.feat()
+	if err != nil {
+		return err
+	}
+	if _, mlstSupported := c.features["MLST"]; mlstSupported {
+		c.mlstSupported = true
 	}
 
 	// Switch to binary mode


### PR DESCRIPTION
Some servers require the user to be logged in to run FEAT

    ftp://serverftp:2121: Connecting to FTP server
    FTP Rx: "220 DrFTPD+ 2.0 (+STABLE+) $Revision: 1949 $ http://drftpd.org"
    FTP Tx: "AUTH TLS"
    FTP Rx: "234 AUTH TLS successful"
    FTP Tx: "FEAT"
    FTP Rx: "530 Not logged in."