### PR TITLE
Fix tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -328,7 +328,7 @@ func openConn(t *testing.T, addr string, options ...DialOption) (*ftpMock, *Serv
 
 // Helper to close a client connected to a mock server
 func closeConn(t *testing.T, mock *ftpMock, c *ServerConn, commands []string) {
-	expected := []string{"FEAT", "USER", "PASS", "TYPE", "OPTS"}
+	expected := []string{"USER", "PASS", "FEAT", "TYPE", "OPTS"}
 	expected = append(expected, commands...)
 	expected = append(expected, "QUIT")
 

--- a/walker_test.go
+++ b/walker_test.go
@@ -104,11 +104,11 @@ func TestEmptyStackReturnsFalse(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	mock, err := newFtpMock(t, "127.0.0.1")
-	require.NotNil(err)
+	require.Nil(err)
 	defer mock.Close()
 
 	c, cErr := Connect(mock.Addr())
-	require.NotNil(cErr)
+	require.Nil(cErr)
 
 	w := c.Walk("/root")
 
@@ -136,11 +136,11 @@ func TestCurAndStackSetCorrectly(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	mock, err := newFtpMock(t, "127.0.0.1")
-	require.NotNil(err)
+	require.Nil(err)
 	defer mock.Close()
 
 	c, cErr := Connect(mock.Addr())
-	require.NotNil(cErr)
+	require.Nil(cErr)
 
 	w := c.Walk("/root")
 	w.cur = &item{


### PR DESCRIPTION
It seems a test relying on command order was broken by #199 

The second issue I'm not sure where it originates from, but it makes sense the return values should be nil.

Fixes #204.