### PR TITLE
trim trailing whitespace from the list commands

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -298,5 +300,22 @@ func TestMissingFolderDeleteDirRecur(t *testing.T) {
 	}
 
 	// Wait for the connection to close
+	mock.Wait()
+}
+
+func TestListCurrentDir(t *testing.T) {
+	mock, c := openConn(t, "127.0.0.1")
+
+	_, err := c.List("")
+	assert.NoError(t, err)
+	assert.Equal(t, "LIST", mock.lastFull, "LIST must not have a trailing whitespace")
+
+	_, err = c.NameList("")
+	assert.NoError(t, err)
+	assert.Equal(t, "NLST", mock.lastFull, "NLST must not have a trailing whitespace")
+
+	err = c.Quit()
+	assert.NoError(t, err)
+
 	mock.Wait()
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -18,6 +18,7 @@ type ftpMock struct {
 	listener *net.TCPListener
 	proto    *textproto.Conn
 	commands []string // list of received commands
+	lastFull string   // full last command
 	rest     int
 	fileCont *bytes.Buffer
 	dataConn *mockDataConn
@@ -66,6 +67,7 @@ func (mock *ftpMock) listen(t *testing.T) {
 
 	for {
 		fullCommand, _ := mock.proto.ReadLine()
+		mock.lastFull = fullCommand
 
 		cmdParts := strings.Split(fullCommand, " ")
 

--- a/ftp.go
+++ b/ftp.go
@@ -539,7 +539,11 @@ func (c *ServerConn) cmdDataConnFrom(offset uint64, format string, args ...inter
 
 // NameList issues an NLST FTP command.
 func (c *ServerConn) NameList(path string) (entries []string, err error) {
-	conn, err := c.cmdDataConnFrom(0, "NLST %s", path)
+	space := " "
+	if path == "" {
+		space = ""
+	}
+	conn, err := c.cmdDataConnFrom(0, "NLST%s%s", space, path)
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +574,11 @@ func (c *ServerConn) List(path string) (entries []*Entry, err error) {
 		parser = parseListLine
 	}
 
-	conn, err := c.cmdDataConnFrom(0, "%s %s", cmd, path)
+	space := " "
+	if path == "" {
+		space = ""
+	}
+	conn, err := c.cmdDataConnFrom(0, "%s%s%s", cmd, space, path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi @jlaffaye 

We are using your great library as a filesystem backend in rclone.
A few rclone users hit a problem with Solaris FTP server, which was discussed in https://github.com/rclone/rclone/issues/1850

Namely, when they list contents of current remote directory, the ftp library concatenates the `LIST` (or `MSLD`) command
with an empty argument and sends `LIST  `   (with a trailing whitespace) out. Most FTP servers are fine with it but Solaris 
FTP replies with `500 Command not understood`. Removing the trailing whitespace fixes the situation for us.

In the first attempt I tried to strip edge whitespace generically on the `cmd` interface level but that resulted in errors.
In this patch I fix it only for `LIST`, `MSLD` and `NLST` commands leaving others as is.

Please approve.
Thank you.