### PR TITLE
Add setting client type before setting chartset to UTF8

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -375,7 +375,7 @@ func (c *ServerConn) setUTF8() error {
 		return err
 	}
 
-	code, message, err := c.cmd(-1, "OPTS UTF8 ON")
+	code, message, err = c.cmd(-1, "OPTS UTF8 ON")
 	if err != nil {
 		return err
 	}

--- a/ftp.go
+++ b/ftp.go
@@ -369,6 +369,12 @@ func (c *ServerConn) setUTF8() error {
 		return nil
 	}
 
+	// Some server request for setting client type before OPTS UTF8
+	code, message, err := c.cmd(-1, "CLNT FTPClient")
+	if err != nil {
+		return err
+	}
+
 	code, message, err := c.cmd(-1, "OPTS UTF8 ON")
 	if err != nil {
 		return err


### PR DESCRIPTION
When I try to connect a FTP server with UTF8 encoding, I get message
```
Send 'CLNT client_type' before enabling UTF8
```

After I add it before the code `OPTS UTF8 ON`, it works.