### PR TITLE
Fix golangci-lint warnings

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -89,7 +89,7 @@ func testConn(t *testing.T, disableEPSV bool) {
 	if err != nil {
 		t.Error(err)
 	} else {
-		r.SetDeadline(time.Now())
+		_ = r.SetDeadline(time.Now())
 		_, err = ioutil.ReadAll(r)
 		if err == nil {
 			t.Error("deadline should have caused error")
@@ -231,7 +231,7 @@ func TestTimeout(t *testing.T) {
 	}
 
 	if c, err := DialTimeout("localhost:2121", 1*time.Second); err == nil {
-		c.Quit()
+		_ = c.Quit()
 		t.Fatal("expected timeout, got nil error")
 	}
 }
@@ -247,7 +247,9 @@ func TestWrongLogin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Quit()
+	defer func() {
+		_ = c.Quit()
+	}()
 
 	err = c.Login("zoo2Shia", "fei5Yix9")
 	if err == nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -63,7 +63,7 @@ func (mock *ftpMock) listen(t *testing.T) {
 	defer conn.Close()
 
 	mock.proto = textproto.NewConn(conn)
-	mock.proto.Writer.PrintfLine("220 FTP Server ready.")
+	_ = mock.proto.Writer.PrintfLine("220 FTP Server ready.")
 
 	for {
 		fullCommand, _ := mock.proto.ReadLine()
@@ -77,142 +77,142 @@ func (mock *ftpMock) listen(t *testing.T) {
 		// At least one command must have a multiline response
 		switch cmdParts[0] {
 		case "FEAT":
-			mock.proto.Writer.PrintfLine("211-Features:\r\n FEAT\r\n PASV\r\n EPSV\r\n UTF8\r\n SIZE\r\n211 End")
+			_ = mock.proto.Writer.PrintfLine("211-Features:\r\n FEAT\r\n PASV\r\n EPSV\r\n UTF8\r\n SIZE\r\n211 End")
 		case "USER":
 			if cmdParts[1] == "anonymous" {
-				mock.proto.Writer.PrintfLine("331 Please send your password")
+				_ = mock.proto.Writer.PrintfLine("331 Please send your password")
 			} else {
-				mock.proto.Writer.PrintfLine("530 This FTP server is anonymous only")
+				_ = mock.proto.Writer.PrintfLine("530 This FTP server is anonymous only")
 			}
 		case "PASS":
-			mock.proto.Writer.PrintfLine("230-Hey,\r\nWelcome to my FTP\r\n230 Access granted")
+			_ = mock.proto.Writer.PrintfLine("230-Hey,\r\nWelcome to my FTP\r\n230 Access granted")
 		case "TYPE":
-			mock.proto.Writer.PrintfLine("200 Type set ok")
+			_ = mock.proto.Writer.PrintfLine("200 Type set ok")
 		case "CWD":
 			if cmdParts[1] == "missing-dir" {
-				mock.proto.Writer.PrintfLine("550 %s: No such file or directory", cmdParts[1])
+				_ = mock.proto.Writer.PrintfLine("550 %s: No such file or directory", cmdParts[1])
 			} else {
-				mock.proto.Writer.PrintfLine("250 Directory successfully changed.")
+				_ = mock.proto.Writer.PrintfLine("250 Directory successfully changed.")
 			}
 		case "DELE":
-			mock.proto.Writer.PrintfLine("250 File successfully removed.")
+			_ = mock.proto.Writer.PrintfLine("250 File successfully removed.")
 		case "MKD":
-			mock.proto.Writer.PrintfLine("257 Directory successfully created.")
+			_ = mock.proto.Writer.PrintfLine("257 Directory successfully created.")
 		case "RMD":
 			if cmdParts[1] == "missing-dir" {
-				mock.proto.Writer.PrintfLine("550 No such file or directory")
+				_ = mock.proto.Writer.PrintfLine("550 No such file or directory")
 			} else {
-				mock.proto.Writer.PrintfLine("250 Directory successfully removed.")
+				_ = mock.proto.Writer.PrintfLine("250 Directory successfully removed.")
 			}
 		case "PWD":
-			mock.proto.Writer.PrintfLine("257 \"/incoming\"")
+			_ = mock.proto.Writer.PrintfLine("257 \"/incoming\"")
 		case "CDUP":
-			mock.proto.Writer.PrintfLine("250 CDUP command successful")
+			_ = mock.proto.Writer.PrintfLine("250 CDUP command successful")
 		case "SIZE":
 			if cmdParts[1] == "magic-file" {
-				mock.proto.Writer.PrintfLine("213 42")
+				_ = mock.proto.Writer.PrintfLine("213 42")
 			} else {
-				mock.proto.Writer.PrintfLine("550 Could not get file size.")
+				_ = mock.proto.Writer.PrintfLine("550 Could not get file size.")
 			}
 		case "PASV":
 			p, err := mock.listenDataConn()
 			if err != nil {
-				mock.proto.Writer.PrintfLine("451 %s.", err)
+				_ = mock.proto.Writer.PrintfLine("451 %s.", err)
 				break
 			}
 
 			p1 := int(p / 256)
 			p2 := p % 256
 
-			mock.proto.Writer.PrintfLine("227 Entering Passive Mode (127,0,0,1,%d,%d).", p1, p2)
+			_ = mock.proto.Writer.PrintfLine("227 Entering Passive Mode (127,0,0,1,%d,%d).", p1, p2)
 		case "EPSV":
 			p, err := mock.listenDataConn()
 			if err != nil {
-				mock.proto.Writer.PrintfLine("451 %s.", err)
+				_ = mock.proto.Writer.PrintfLine("451 %s.", err)
 				break
 			}
-			mock.proto.Writer.PrintfLine("229 Entering Extended Passive Mode (|||%d|)", p)
+			_ = mock.proto.Writer.PrintfLine("229 Entering Extended Passive Mode (|||%d|)", p)
 		case "STOR":
 			if mock.dataConn == nil {
-				mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
+				_ = mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
 				break
 			}
-			mock.proto.Writer.PrintfLine("150 please send")
+			_ = mock.proto.Writer.PrintfLine("150 please send")
 			mock.recvDataConn(false)
 		case "APPE":
 			if mock.dataConn == nil {
-				mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
+				_ = mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
 				break
 			}
-			mock.proto.Writer.PrintfLine("150 please send")
+			_ = mock.proto.Writer.PrintfLine("150 please send")
 			mock.recvDataConn(true)
 		case "LIST":
 			if mock.dataConn == nil {
-				mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
+				_ = mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
 				break
 			}
 
 			mock.dataConn.Wait()
-			mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
-			mock.dataConn.conn.Write([]byte("-rw-r--r--   1 ftp      wheel           0 Jan 29 10:29 lo"))
-			mock.proto.Writer.PrintfLine("226 Transfer complete")
-			mock.closeDataConn()
+			_ = mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
+			_, _ = mock.dataConn.conn.Write([]byte("-rw-r--r--   1 ftp      wheel           0 Jan 29 10:29 lo"))
+			_ = mock.proto.Writer.PrintfLine("226 Transfer complete")
+			_ = mock.closeDataConn()
 		case "NLST":
 			if mock.dataConn == nil {
-				mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
+				_ = mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
 				break
 			}
 
 			mock.dataConn.Wait()
-			mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
-			mock.dataConn.conn.Write([]byte("/incoming"))
-			mock.proto.Writer.PrintfLine("226 Transfer complete")
-			mock.closeDataConn()
+			_ = mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
+			_, _ = mock.dataConn.conn.Write([]byte("/incoming"))
+			_ = mock.proto.Writer.PrintfLine("226 Transfer complete")
+			_ = mock.closeDataConn()
 		case "RETR":
 			if mock.dataConn == nil {
-				mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
+				_ = mock.proto.Writer.PrintfLine("425 Unable to build data connection: Connection refused")
 				break
 			}
 
 			mock.dataConn.Wait()
-			mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
-			mock.dataConn.conn.Write(mock.fileCont.Bytes()[mock.rest:])
+			_ = mock.proto.Writer.PrintfLine("150 Opening ASCII mode data connection for file list")
+			_, _ = mock.dataConn.conn.Write(mock.fileCont.Bytes()[mock.rest:])
 			mock.rest = 0
-			mock.proto.Writer.PrintfLine("226 Transfer complete")
-			mock.closeDataConn()
+			_ = mock.proto.Writer.PrintfLine("226 Transfer complete")
+			_ = mock.closeDataConn()
 		case "RNFR":
-			mock.proto.Writer.PrintfLine("350 File or directory exists, ready for destination name")
+			_ = mock.proto.Writer.PrintfLine("350 File or directory exists, ready for destination name")
 		case "RNTO":
-			mock.proto.Writer.PrintfLine("250 Rename successful")
+			_ = mock.proto.Writer.PrintfLine("250 Rename successful")
 		case "REST":
 			if len(cmdParts) != 2 {
-				mock.proto.Writer.PrintfLine("500 wrong number of arguments")
+				_ = mock.proto.Writer.PrintfLine("500 wrong number of arguments")
 				break
 			}
 			rest, err := strconv.Atoi(cmdParts[1])
 			if err != nil {
-				mock.proto.Writer.PrintfLine("500 REST: %s", err)
+				_ = mock.proto.Writer.PrintfLine("500 REST: %s", err)
 				break
 			}
 			mock.rest = rest
-			mock.proto.Writer.PrintfLine("350 Restarting at %s. Send STORE or RETRIEVE to initiate transfer", cmdParts[1])
+			_ = mock.proto.Writer.PrintfLine("350 Restarting at %s. Send STORE or RETRIEVE to initiate transfer", cmdParts[1])
 		case "NOOP":
-			mock.proto.Writer.PrintfLine("200 NOOP ok.")
+			_ = mock.proto.Writer.PrintfLine("200 NOOP ok.")
 		case "OPTS":
 			if len(cmdParts) != 3 {
-				mock.proto.Writer.PrintfLine("500 wrong number of arguments")
+				_ = mock.proto.Writer.PrintfLine("500 wrong number of arguments")
 				break
 			}
 			if (strings.Join(cmdParts[1:], " ")) == "UTF8 ON" {
-				mock.proto.Writer.PrintfLine("200 OK, UTF-8 enabled")
+				_ = mock.proto.Writer.PrintfLine("200 OK, UTF-8 enabled")
 			}
 		case "REIN":
-			mock.proto.Writer.PrintfLine("220 Logged out")
+			_ = mock.proto.Writer.PrintfLine("220 Logged out")
 		case "QUIT":
-			mock.proto.Writer.PrintfLine("221 Goodbye.")
+			_ = mock.proto.Writer.PrintfLine("221 Goodbye.")
 			return
 		default:
-			mock.proto.Writer.PrintfLine("500 Unknown command %s.", cmdParts[0])
+			_ = mock.proto.Writer.PrintfLine("500 Unknown command %s.", cmdParts[0])
 		}
 	}
 }
@@ -243,7 +243,7 @@ func (d *mockDataConn) Close() (err error) {
 }
 
 func (mock *ftpMock) listenDataConn() (int64, error) {
-	mock.closeDataConn()
+	_ = mock.closeDataConn()
 
 	l, err := net.Listen("tcp", mock.address+":0")
 	if err != nil {
@@ -291,9 +291,9 @@ func (mock *ftpMock) recvDataConn(append bool) {
 	if !append {
 		mock.fileCont = new(bytes.Buffer)
 	}
-	io.Copy(mock.fileCont, mock.dataConn.conn)
-	mock.proto.Writer.PrintfLine("226 Transfer Complete")
-	mock.closeDataConn()
+	_, _ = io.Copy(mock.fileCont, mock.dataConn.conn)
+	_ = mock.proto.Writer.PrintfLine("226 Transfer Complete")
+	_ = mock.closeDataConn()
 }
 
 func (mock *ftpMock) Addr() string {


### PR DESCRIPTION
This proposal does not introduce behavior changes, just makes the library code a little bit cleaner.

If you run `golangci-lint run .` on the library, it will warn many function invocations that implicitly drop returned values without analysis. This patch makes the drops explicit.