### PR TITLE
Debug directory listings

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -19,3 +19,19 @@ func newDebugWrapper(conn io.ReadWriteCloser, w io.Writer) io.ReadWriteCloser {
 func (w *debugWrapper) Close() error {
 	return w.conn.Close()
 }
+
+type streamDebugWrapper struct {
+	io.Reader
+	closer io.ReadCloser
+}
+
+func newStreamDebugWrapper(rd io.ReadCloser, w io.Writer) io.ReadCloser {
+	return &streamDebugWrapper{
+		Reader: io.TeeReader(rd, w),
+		closer: rd,
+	}
+}
+
+func (w *streamDebugWrapper) Close() error {
+	return w.closer.Close()
+}


### PR DESCRIPTION
This library provides the `DialWithDebugOutput` dial option that allows applications to debug live protocol messages. This patch adds directory listings to the debug output.