### PR TITLE
add modtime to library

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -656,6 +656,16 @@ func (c *ServerConn) FileSize(path string) (int64, error) {
 	return strconv.ParseInt(msg, 10, 64)
 }
 
+// ModTime issues a MODTIME FTP command, which Returns the modtime of the file
+func (c *ServerConn) ModTime(path string) (string, error) {
+	_, msg, err := c.cmd(StatusFile, "MODTIME %s", path)
+	if err != nil {
+		return "", err
+	}
+
+	return msg, nil
+}
+
 // Retr issues a RETR FTP command to fetch the specified file from the remote
 // FTP server.
 //


### PR DESCRIPTION
just a small addition to library [thanks for building it - much appreciated!]

A better addition really would be just making the cmd method public - so people can add their own FTP Commands even when importing this pkg.

i.e

```
// Command is an exported helper function to execute your own commands
// i.e anything from -> https://www.ftp-commands.com/file-transfer-protocol/modtime-file-name/
func (c *ServerConn) Command(expected int, format string, args ...interface{}) (int, string, error) {
	_, err := c.conn.cmd(format, args...)
	if err != nil {
		return 0, "", err
	}

	return c.conn.ReadResponse(expected)
}
```

forgive me if there's already a methodology in place in the library for this to be done