### PR TITLE
Nudge control connection deadline before reading the data closing status (Try 2)

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -32,7 +32,8 @@ const (
 // It is not safe to be called concurrently.
 type ServerConn struct {
 	options *dialOptions
-	conn    *textproto.Conn
+	conn    *textproto.Conn // connection wrapper for text protocol
+	netConn net.Conn        // underlying network connection
 	host    string
 
 	// Server capabilities discovered at runtime
@@ -60,6 +61,7 @@ type dialOptions struct {
 	location    *time.Location
 	debugOutput io.Writer
 	dialFunc    func(network, address string) (net.Conn, error)
+	shutTimeout time.Duration // time to wait for data connection closing status
 }
 
 // Entry describes a file and is returned by List().
@@ -120,6 +122,7 @@ func Dial(addr string, options ...DialOption) (*ServerConn, error) {
 		options:  do,
 		features: make(map[string]string),
 		conn:     textproto.NewConn(do.wrapConn(tconn)),
+		netConn:  tconn,
 		host:     remoteAddr.IP.String(),
 	}
 
@@ -145,6 +148,15 @@ func Dial(addr string, options ...DialOption) (*ServerConn, error) {
 func DialWithTimeout(timeout time.Duration) DialOption {
 	return DialOption{func(do *dialOptions) {
 		do.dialer.Timeout = timeout
+	}}
+}
+
+// DialWithShutTimeout returns a DialOption that configures the ServerConn with
+// maximum time to wait for the data closing status on control connection
+// and nudging the control connection deadline before reading status.
+func DialWithShutTimeout(shutTimeout time.Duration) DialOption {
+	return DialOption{func(do *dialOptions) {
+		do.shutTimeout = shutTimeout
 	}}
 }
 
@@ -685,6 +697,24 @@ func (c *ServerConn) Stor(path string, r io.Reader) error {
 	return c.StorFrom(path, r, 0)
 }
 
+// checkDataShut reads the "closing data connection" status from the
+// control connection. It is called after transferring a piece of data
+// on the data connection during which the control connection was idle.
+// This may result in the idle timeout triggering on the control connection
+// right when we try to read the response.
+// The ShutTimeout dial option will rescue here. It will nudge the control
+// connection deadline right before checking the data closing status.
+func (c *ServerConn) checkDataShut() error {
+	if c.options.shutTimeout != 0 {
+		shutDeadline := time.Now().Add(c.options.shutTimeout)
+		if err := c.netConn.SetDeadline(shutDeadline); err != nil {
+			return err
+		}
+	}
+	_, _, err := c.conn.ReadResponse(StatusClosingDataConnection)
+	return err
+}
+
 // StorFrom issues a STOR FTP command to store a file to the remote FTP server.
 // Stor creates the specified file with the content of the io.Reader, writing
 // on the server will start at the given file offset.
@@ -726,7 +756,7 @@ func (c *ServerConn) StorFrom(path string, r io.Reader, offset uint64) error {
 
 	// Read the response and use this error in preference to
 	// previous errors
-	_, _, respErr := c.conn.ReadResponse(StatusClosingDataConnection)
+	respErr := c.checkDataShut()
 	if respErr != nil {
 		err = respErr
 	}
@@ -748,7 +778,7 @@ func (c *ServerConn) Append(path string, r io.Reader) error {
 	_, err = io.Copy(conn, r)
 	errClose := conn.Close()
 
-	_, _, respErr := c.conn.ReadResponse(StatusClosingDataConnection)
+	respErr := c.checkDataShut()
 	if respErr != nil {
 		err = respErr
 	}
@@ -889,7 +919,7 @@ func (r *Response) Close() error {
 		return nil
 	}
 	err := r.conn.Close()
-	_, _, err2 := r.c.conn.ReadResponse(StatusClosingDataConnection)
+	err2 := r.c.checkDataShut()
 	if err2 != nil {
 		err = err2
 	}


### PR DESCRIPTION
### My previous attempt to submit this patch for review was closed by stale bot after month of no reply from maintainer. @jlaffaye is this project actively maintained?

#### Problem

Uploading of large files via this library and rclone frequently ends up with `i/o timeout`.

My investigation shows the following:
- `jlaffaye/ftp` makes control/data streams from a connection factory provided by rclone. This factory wraps standard go tcp streams in the [code](https://github.com/rclone/rclone/blob/v1.56.0/fs/fshttp/dialer.go#L85) which safeguards against silently dead network connections (lost without explicit TCP shutdown), namely cancels streams after timeout but resets timeout timer after each read/write.
- A typical FTP upload looks like: client talks with ftp server on control stream, sets upload parameters, then create one or more data streams and do the upload (this can be long), then return to control stream and ask ftp server about upload results  (here be dragons)
- While client was busy uploading on data stream, the control stream timeout happened and client's attempt to read status returned **I/O timeout**

#### Solution

This patch makes this FTP library "nudge" the control connection right after a (probably long) upload has finished. Note that by default I don't change previous behavior for compatibility with other library users but add a dedicated option. I will also submit a relevant rclone PR.

#### Test

I don't think a synthetic unit test will have any importance for this change, just boost a synthetic coverage rating.

Instead, I wrote a more practical unit test using a containerized PureFtpd and rclone as a wrapper here:
https://github.com/rclone/rclone/pull/5596/files#diff-67452ac6849fa36379c4aa76d2d528fd2dbe411ac03493522a63e59ea03a8c40R57
and asked end users to compare behavior with and without the patch in practice.

In fact the problem with big file uploads was very hot on rclone tracker and forum. Derivative manifestations of this problem were reported a number of times:
- https://forum.rclone.org/t/rclone-copy-to-ftp-rclone-sends-a-quit-and-never-ends-itself/24046
- https://github.com/rclone/rclone/issues/5328
- https://github.com/rclone/rclone/issues/4622
- https://github.com/rclone/rclone/pull/5590 (fixes consequences)

@jlaffaye Please review...