### PR TITLE
support for the TYPE command

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -28,6 +28,15 @@ const (
 	EntryTypeLink
 )
 
+// TransferType denotes the formats for transfering Entries.
+type TransferType string
+
+// The different transfer types
+const (
+	TransferTypeImage = "I"
+	TransferTypeASCII = "A"
+)
+
 // Time format used by the MDTM and MFMT commands
 const timeFormat = "20060102150405"
 
@@ -340,7 +349,7 @@ func (c *ServerConn) Login(user, password string) error {
 	c.mdtmCanWrite = c.mdtmSupported && c.options.writingMDTM
 
 	// Switch to binary mode
-	if _, _, err = c.cmd(StatusCommandOK, "TYPE I"); err != nil {
+	if err = c.Type(TransferTypeImage); err != nil {
 		return err
 	}
 
@@ -578,6 +587,12 @@ func (c *ServerConn) cmdDataConnFrom(offset uint64, format string, args ...inter
 	}
 
 	return conn, nil
+}
+
+// Type switches the transfer mode for the connection.
+func (c *ServerConn) Type(transferType TransferType) (err error) {
+	_, _, err = c.cmd(StatusCommandOK, "TYPE "+string(transferType))
+	return err
 }
 
 // NameList issues an NLST FTP command.

--- a/ftp.go
+++ b/ftp.go
@@ -33,8 +33,8 @@ type TransferType string
 
 // The different transfer types
 const (
-	TransferTypeImage = "I"
-	TransferTypeASCII = "A"
+	TransferTypeBinary = "I"
+	TransferTypeASCII  = "A"
 )
 
 // Time format used by the MDTM and MFMT commands
@@ -349,7 +349,7 @@ func (c *ServerConn) Login(user, password string) error {
 	c.mdtmCanWrite = c.mdtmSupported && c.options.writingMDTM
 
 	// Switch to binary mode
-	if err = c.Type(TransferTypeImage); err != nil {
+	if err = c.Type(TransferTypeBinary); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds support for the ftp TYPE command to control the format used by the ftp server to transfer data. The new  function `Type(transferType TransferType)` enables switching between transfer types. Two constants for `TransferType` are defined, one for image/binary and one for ascii.