### PR TITLE
Add MLST command in the form of a Get method

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -153,6 +153,23 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Fatal("expected error, got nil")
 	}
 
+	entry, err := c.Get("magic-file")
+	if err != nil {
+		t.Error(err)
+	}
+	if entry == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if entry.Size != 42 {
+		t.Errorf("entry size %q, expected %q", entry.Size, 42)
+	}
+	if entry.Type != EntryTypeFile {
+		t.Errorf("entry type %q, expected %q", entry.Type, EntryTypeFile)
+	}
+	if entry.Name != "magic-file" {
+		t.Errorf("entry name %q, expected %q", entry.Name, "magic-file")
+	}
+
 	err = c.Delete("tset")
 	if err != nil {
 		t.Error(err)
@@ -312,7 +329,7 @@ func TestMissingFolderDeleteDirRecur(t *testing.T) {
 }
 
 func TestListCurrentDir(t *testing.T) {
-	mock, c := openConn(t, "127.0.0.1")
+	mock, c := openConnExt(t, "127.0.0.1", "no-time", DialWithDisabledMLSD(true))
 
 	_, err := c.List("")
 	assert.NoError(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -153,7 +153,7 @@ func testConn(t *testing.T, disableEPSV bool) {
 		t.Fatal("expected error, got nil")
 	}
 
-	entry, err := c.Get("magic-file")
+	entry, err := c.GetEntry("magic-file")
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,6 +168,23 @@ func testConn(t *testing.T, disableEPSV bool) {
 	}
 	if entry.Name != "magic-file" {
 		t.Errorf("entry name %q, expected %q", entry.Name, "magic-file")
+	}
+
+	entry, err = c.GetEntry("multiline-dir")
+	if err != nil {
+		t.Error(err)
+	}
+	if entry == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if entry.Size != 0 {
+		t.Errorf("entry size %q, expected %q", entry.Size, 0)
+	}
+	if entry.Type != EntryTypeFolder {
+		t.Errorf("entry type %q, expected %q", entry.Type, EntryTypeFolder)
+	}
+	if entry.Name != "multiline-dir" {
+		t.Errorf("entry name %q, expected %q", entry.Name, "multiline-dir")
 	}
 
 	err = c.Delete("tset")

--- a/conn_test.go
+++ b/conn_test.go
@@ -188,7 +188,11 @@ func (mock *ftpMock) listen() {
 			mock.printfLine("226 Transfer complete")
 			mock.closeDataConn()
 		case "MLST":
-			mock.printfLine("250-File data\r\nType=file;Size=42;Modify=20201213202400; magic-file\r\n250 End")
+			if cmdParts[1] == "multiline-dir" {
+				mock.printfLine("250-File data\r\n Type=dir;Size=0; multiline-dir\r\n Modify=20201213202400; multiline-dir\r\n250 End")
+			} else {
+				mock.printfLine("250-File data\r\n Type=file;Size=42;Modify=20201213202400; magic-file\r\n250 End")
+			}
 		case "NLST":
 			if mock.dataConn == nil {
 				mock.printfLine("425 Unable to build data connection: Connection refused")

--- a/conn_test.go
+++ b/conn_test.go
@@ -88,7 +88,7 @@ func (mock *ftpMock) listen() {
 		// At least one command must have a multiline response
 		switch cmdParts[0] {
 		case "FEAT":
-			features := "211-Features:\r\n FEAT\r\n PASV\r\n EPSV\r\n UTF8\r\n SIZE\r\n"
+			features := "211-Features:\r\n FEAT\r\n PASV\r\n EPSV\r\n UTF8\r\n SIZE\r\n MLST\r\n"
 			switch mock.modtime {
 			case "std-time":
 				features += " MDTM\r\n MFMT\r\n"
@@ -176,6 +176,19 @@ func (mock *ftpMock) listen() {
 			mock.dataConn.write([]byte("-rw-r--r--   1 ftp      wheel           0 Jan 29 10:29 lo\r\ntotal 1"))
 			mock.printfLine("226 Transfer complete")
 			mock.closeDataConn()
+		case "MLSD":
+			if mock.dataConn == nil {
+				mock.printfLine("425 Unable to build data connection: Connection refused")
+				break
+			}
+
+			mock.dataConn.Wait()
+			mock.printfLine("150 Opening data connection for file list")
+			mock.dataConn.write([]byte("Type=file;Size=0;Modify=20201213202400; lo\r\n"))
+			mock.printfLine("226 Transfer complete")
+			mock.closeDataConn()
+		case "MLST":
+			mock.printfLine("250-File data\r\nType=file;Size=42;Modify=20201213202400; magic-file\r\n250 End")
 		case "NLST":
 			if mock.dataConn == nil {
 				mock.printfLine("425 Unable to build data connection: Connection refused")

--- a/ftp.go
+++ b/ftp.go
@@ -675,7 +675,7 @@ func (c *ServerConn) List(path string) (entries []*Entry, err error) {
 // when no path is given.
 func (c *ServerConn) GetEntry(path string) (entry *Entry, err error) {
 	if !c.mlstSupported {
-		return nil, &textproto.Error{StatusNotImplemented, StatusText(StatusNotImplemented)}
+		return nil, &textproto.Error{Code: StatusNotImplemented, Msg: StatusText(StatusNotImplemented)}
 	}
 	space := " "
 	if path == "" {

--- a/ftp.go
+++ b/ftp.go
@@ -685,6 +685,19 @@ func (c *ServerConn) GetEntry(path string) (entry *Entry, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// The expected reply will look something like:
+	//
+	//    250-File details
+	//     Type=file;Size=1024;Modify=20220813133357; path
+	//    250 End
+	//
+	// Multiple lines are allowed though, so it can also be in the form:
+	//
+	//    250-File details
+	//     Type=file;Size=1024; path
+	//     Modify=20220813133357; path
+	//    250 End
 	lines := strings.Split(msg, "\n")
 	lc := len(lines)
 

--- a/ftp.go
+++ b/ftp.go
@@ -715,7 +715,7 @@ func (c *ServerConn) GetEntry(path string) (entry *Entry, err error) {
 		if len(l) > 0 && l[0] == ' ' {
 			l = l[1:]
 		}
-		if e, err = parseNextRFC3659ListLine(l, time.Now(), c.options.location, e); err != nil {
+		if e, err = parseNextRFC3659ListLine(l, c.options.location, e); err != nil {
 			return nil, err
 		}
 	}

--- a/parse.go
+++ b/parse.go
@@ -28,6 +28,10 @@ var dirTimeFormats = []string{
 
 // parseRFC3659ListLine parses the style of directory line defined in RFC 3659.
 func parseRFC3659ListLine(line string, now time.Time, loc *time.Location) (*Entry, error) {
+	return parseNextRFC3659ListLine(line, now, loc, &Entry{})
+}
+
+func parseNextRFC3659ListLine(line string, _ time.Time, loc *time.Location, e *Entry) (*Entry, error) {
 	iSemicolon := strings.Index(line, ";")
 	iWhitespace := strings.Index(line, " ")
 
@@ -35,8 +39,12 @@ func parseRFC3659ListLine(line string, now time.Time, loc *time.Location) (*Entr
 		return nil, errUnsupportedListLine
 	}
 
-	e := &Entry{
-		Name: line[iWhitespace+1:],
+	name := line[iWhitespace+1:]
+	if e.Name == "" {
+		e.Name = name
+	} else if e.Name != name {
+		// All lines must have the same name
+		return nil, errUnsupportedListLine
 	}
 
 	for _, field := range strings.Split(line[:iWhitespace-1], ";") {

--- a/parse.go
+++ b/parse.go
@@ -27,11 +27,11 @@ var dirTimeFormats = []string{
 }
 
 // parseRFC3659ListLine parses the style of directory line defined in RFC 3659.
-func parseRFC3659ListLine(line string, now time.Time, loc *time.Location) (*Entry, error) {
-	return parseNextRFC3659ListLine(line, now, loc, &Entry{})
+func parseRFC3659ListLine(line string, _ time.Time, loc *time.Location) (*Entry, error) {
+	return parseNextRFC3659ListLine(line, loc, &Entry{})
 }
 
-func parseNextRFC3659ListLine(line string, _ time.Time, loc *time.Location, e *Entry) (*Entry, error) {
+func parseNextRFC3659ListLine(line string, loc *time.Location, e *Entry) (*Entry, error) {
 	iSemicolon := strings.Index(line, ";")
 	iWhitespace := strings.Index(line, " ")
 


### PR DESCRIPTION
The `LIST` and `MLSD` commands are inefficient when the objective
is to retrieve one single `Entry` for a known path, because the only way
to get such an entry is to list the parent directory using a data
connection. The `MLST` fixes this by allowing one single `Entry` to be
returned using the control connection.

The name `Get` was chosen because it is often used in conjunction with
`List` as a mean to get one single entry.

Signed-off-by: Thomas Hallgren <thomas@datawire.io>