### PR TITLE
Add forceListHidden dial option to force the use of 'LIST -a' command

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -295,6 +295,20 @@ func TestListCurrentDir(t *testing.T) {
 	mock.Wait()
 }
 
+func TestListCurrentDirWithForceListHidden(t *testing.T) {
+	mock, c := openConnExt(t, "127.0.0.1", "no-time", DialWithDisabledMLSD(true), DialWithForceListHidden(true))
+
+	assert.True(t, c.options.forceListHidden)
+	_, err := c.List("")
+	assert.NoError(t, err)
+	assert.Equal(t, "LIST -a", mock.lastFull, "LIST -a must not have a trailing whitespace")
+
+	err = c.Quit()
+	assert.NoError(t, err)
+
+	mock.Wait()
+}
+
 func TestTimeUnsupported(t *testing.T) {
 	mock, c := openConnExt(t, "127.0.0.1", "no-time")
 

--- a/walker.go
+++ b/walker.go
@@ -4,7 +4,7 @@ import (
 	"path"
 )
 
-//Walker traverses the directory tree of a remote FTP server
+// Walker traverses the directory tree of a remote FTP server
 type Walker struct {
 	serverConn *ServerConn
 	root       string


### PR DESCRIPTION
This is useful for servers that do not offer up
hidden folders/files by default when using LIST/MLSD
commands.
Setting forceListHidden to true will force the use of
the 'LIST -a' command even when MLST support has
been detected.

This is a fairly quick solution I put together to create a similar behaviour as FileZilla has when the option "Force showing hidden files" is enabled. I haven't created a build to test it yet but posting this early in case there is some fundamental flaw in my approach.
There is even an old stale issue that requested this: #136