### PR TITLE
Fix STOR of zero length files to ProFTPd/pureftpd with TLS (again)

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -912,8 +912,21 @@ func (c *ServerConn) StorFrom(path string, r io.Reader, offset uint64) error {
 	// response otherwise if the failure is not due to a connection problem,
 	// for example the server denied the upload for quota limits, we miss
 	// the response and we cannot use the connection to send other commands.
-	if _, err := io.Copy(conn, r); err != nil {
+	if n, err := io.Copy(conn, r); err != nil {
 		errs = multierror.Append(errs, err)
+	} else if n == 0 {
+		// If we wrote no bytes and got no error, make sure we call
+		// tls.Handshake on the connection as it won't get called
+		// unless Write() is called.
+		//
+		// ProFTP doesn't like this and returns "Unable to build data
+		// connection: Operation not permitted" when trying to upload
+		// an empty file without this.
+		if do, ok := conn.(interface{ Handshake() error }); ok {
+			if err := do.Handshake(); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		}
 	}
 
 	if err := conn.Close(); err != nil {


### PR DESCRIPTION
Before this change, uploading a zero length file via TLS meant that the tls.Handshake function was never called.

ProFTPd and pureftpd refuse to accept an empty TCP connection with no TLS handshake as a zero length upload and gives the error

    425 Unable to build data connection: Operation not

This fix was originally merged in
a4e9650823896675ddb6c11a88f6362912810874
however it got accidentally reverted in
212daf295f0e6ae44131ea12ee353a13fca71091
so this patch re-adds the code, reworked for the subsequent changes.

See: https://forum.rclone.org/t/rclone-ftps-explicit-rclone-touch-empty-files-proftpd-unable-to-build-data-connection-operation-not-permitted/22522
See: https://github.com/rclone/rclone/issues/6426#issuecomment-1243993039