### PR TITLE
add SendCommand

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -163,6 +163,17 @@ func testConn(t *testing.T, disableEPSV bool) {
 	err = c.RemoveDir(testDir)
 	assert.NoError(err)
 
+	code, response, err := c.SendCommand("NOOP")
+	if err != nil {
+		t.Error(err)
+	}
+	if code != StatusCommandOK {
+		t.Errorf("Unexpected status code, got %d, want %d", code, StatusCommandOK)
+	}
+	if response != "NOOP ok." {
+		t.Errorf("Unexpected custom command response %q", response)
+	}
+
 	err = c.Logout()
 	assert.NoError(err)
 

--- a/ftp.go
+++ b/ftp.go
@@ -1080,6 +1080,13 @@ func (c *ServerConn) NoOp() error {
 	return err
 }
 
+// SendCommand issues the specified command on the control connection.
+// Returns the response code, the response message and error if any.
+// This is useful for server specific implementations, for example SITE command.
+func (c *ServerConn) SendCommand(command string, args ...interface{}) (int, string, error) {
+	return c.cmd(-1, command, args...)
+}
+
 // Logout issues a REIN FTP command to logout the current user.
 func (c *ServerConn) Logout() error {
 	_, _, err := c.cmd(StatusReady, "REIN")


### PR DESCRIPTION
SendCommand issues the specified command on the control connection. 
Returns the response code, the response message and error if any. 
This is useful for server specific implementations, for example `SITE` command.