### PR TITLE
Fix GetEntry / MLST for some servers - Fixes #321

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -193,7 +193,7 @@ func (mock *ftpMock) listen() {
 			if cmdParts[1] == "multiline-dir" {
 				mock.printfLine("250-File data\r\n Type=dir;Size=0; multiline-dir\r\n Modify=20201213202400; multiline-dir\r\n250 End")
 			} else {
-				mock.printfLine("250-File data\r\n Type=file;Size=42;Modify=20201213202400; magic-file\r\n250 End")
+				mock.printfLine("250-File data\r\n Type=file;Size=42;Modify=20201213202400; magic-file\r\n \r\n250 End")
 			}
 		case "NLST":
 			if mock.dataConn == nil {

--- a/ftp.go
+++ b/ftp.go
@@ -766,6 +766,10 @@ func (c *ServerConn) GetEntry(path string) (entry *Entry, err error) {
 		if len(l) > 0 && l[0] == ' ' {
 			l = l[1:]
 		}
+		// Some severs seem to send a blank line at the end which we ignore
+		if l == "" {
+			continue
+		}
 		if e, err = parseNextRFC3659ListLine(l, c.options.location, e); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Some servers seem to send a blank line at the end of an MLST response.

    MLST Download
    250-
    Size=53248;Modify=20230327134339.000;Type=dir; Download

    250 Requested file action okay, completed.

Before this change this would cause the GetEntry method to return this error.

    unsupported LIST line

This patch ignores blank lines in the MLST response.