### PR TITLE
Fix PASV address like lftp does

### DIFF
--- a/ftp_test.go
+++ b/ftp_test.go
@@ -1,0 +1,22 @@
+package ftp
+
+import (
+	"net"
+	"testing"
+)
+
+func TestBogusDataIP(t *testing.T) {
+	for _, tC := range []struct {
+		cmd, data net.IP
+		bogus     bool
+	}{
+		{net.IPv4(192, 168, 1, 1), net.IPv4(192, 168, 1, 1), false},
+		{net.IPv4(192, 168, 1, 1), net.IPv4(1, 1, 1, 1), true},
+		{net.IPv4(10, 65, 1, 1), net.IPv4(1, 1, 1, 1), true},
+		{net.IPv4(10, 65, 25, 1), net.IPv4(10, 65, 8, 1), false},
+	} {
+		if got, want := isBogusDataIP(tC.cmd, tC.data), tC.bogus; got != want {
+			t.Errorf("%s,%s got %t, wanted %t", tC.cmd, tC.data, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Some servers responds with their private (inner network) address, not with the publicly reachable one.
In this case, use the original (command) address.