### PR TITLE
Fix PASV address like lftp does

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -528,7 +528,24 @@ func (c *ServerConn) pasv() (host string, port int, err error) {
 
 	// Make the IP address to connect to
 	host = strings.Join(pasvData[0:4], ".")
+
+	if c.host != host {
+		if cmdIP := net.ParseIP(c.host); cmdIP != nil {
+			if dataIP := net.ParseIP(host); dataIP != nil {
+				if isBogusDataIP(cmdIP, dataIP) {
+					return c.host, port, nil
+				}
+			}
+		}
+	}
 	return host, port, nil
+}
+
+func isBogusDataIP(cmdIP, dataIP net.IP) bool {
+	// Logic stolen from lftp (https://github.com/lavv17/lftp/blob/d67fc14d085849a6b0418bb3e912fea2e94c18d1/src/ftpclass.cc#L769)
+	return dataIP.IsMulticast() ||
+		cmdIP.IsPrivate() != dataIP.IsPrivate() ||
+		cmdIP.IsLoopback() != dataIP.IsLoopback()
 }
 
 // getDataConnPort returns a host, port for a new data connection

--- a/ftp_test.go
+++ b/ftp_test.go
@@ -1,0 +1,22 @@
+package ftp
+
+import (
+	"net"
+	"testing"
+)
+
+func TestBogusDataIP(t *testing.T) {
+	for _, tC := range []struct {
+		cmd, data net.IP
+		bogus     bool
+	}{
+		{net.IPv4(192, 168, 1, 1), net.IPv4(192, 168, 1, 1), false},
+		{net.IPv4(192, 168, 1, 1), net.IPv4(1, 1, 1, 1), true},
+		{net.IPv4(10, 65, 1, 1), net.IPv4(1, 1, 1, 1), true},
+		{net.IPv4(10, 65, 25, 1), net.IPv4(10, 65, 8, 1), false},
+	} {
+		if got, want := isBogusDataIP(tC.cmd, tC.data), tC.bogus; got != want {
+			t.Errorf("%s,%s got %t, wanted %t", tC.cmd, tC.data, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Some behind-firewall-and-corporate-network FTP servers responds their private-net address instead of the
publicly reachable.

This fix checks for such address and uses the
command channel's address instead.