### PR TITLE
Fix passive mode with proxy dialer

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -161,7 +161,7 @@ func Dial(addr string, options ...DialOption) (*ServerConn, error) {
 		return nil, err
 	}
 
-	tconn, err := dialFunc("tcp", fmt.Sprintf("%s:%s", addrs[0].IP.String(), port))
+	tconn, err := dialFunc("tcp", net.JoinHostPort(addrs[0].IP.String(), port))
 	if err != nil {
 		return nil, err
 	}

--- a/ftp.go
+++ b/ftp.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/textproto"


### PR DESCRIPTION
The current code will return the IP from the dialer function which in the case of a proxy, is the ip of the proxy, not the IP of the remote host. This fixes the issue.