### PR TITLE
Fix GetEntry / MLST for servers which send multiple spaces

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -192,7 +192,7 @@ func (mock *ftpMock) listen() {
 			if cmdParts[1] == "multiline-dir" {
 				mock.printfLine("250-File data\r\n Type=dir;Size=0; multiline-dir\r\n Modify=20201213202400; multiline-dir\r\n250 End")
 			} else {
-				mock.printfLine("250-File data\r\n Type=file;Size=42;Modify=20201213202400; magic-file\r\n \r\n250 End")
+				mock.printfLine("250-File data\r\n  Type=file;Size=42;Modify=20201213202400; magic-file\r\n \r\n250 End")
 			}
 		case "NLST":
 			if mock.dataConn == nil {

--- a/ftp.go
+++ b/ftp.go
@@ -780,9 +780,9 @@ func (c *ServerConn) GetEntry(path string) (entry *Entry, err error) {
 	e := &Entry{}
 	for _, l := range lines[1 : lc-1] {
 		// According to RFC 3659, the entry lines must start with a space when passed over the
-		// control connection. Some servers don't seem to add that space though. Both forms are
-		// accepted here.
-		if len(l) > 0 && l[0] == ' ' {
+		// control connection. Some servers don't seem to add that space though and some servers
+		// add multiple spaces. All forms are accepted here.
+		for len(l) > 0 && l[0] == ' ' {
 			l = l[1:]
 		}
 		// Some severs seem to send a blank line at the end which we ignore


### PR DESCRIPTION
Some servers seem to send multiple spaces at the end of an MLST response.

    MLST Workspace
    250-Listing Workspace
      size=0;type=dir;perm=rwx;modify=20250218125218; /Workspace
    250 End

Before this change this would cause the GetEntry method to return this
error.

    unsupported LIST line

This patch ignores zero or more spaces at the start of the MLST response.

This was originally discovered in https://github.com/rclone/rclone/issues/8403
