### PR TITLE
Add LIST parser for IBM i (AS/400) QTCP FTP servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jlaffaye/ftp
+module github.com/xiatechs/ftp
 
 go 1.20
 

--- a/parse.go
+++ b/parse.go
@@ -19,6 +19,7 @@ var listLineParsers = []parseFunc{
 	parseLsListLine,
 	parseDirListLine,
 	parseHostedFTPLine,
+	parseAS400ListLine,
 }
 
 var dirTimeFormats = []string{
@@ -225,6 +226,59 @@ func parseHostedFTPLine(line string, now time.Time, loc *time.Location) (*Entry,
 
 	// Set link count to 1 and attempt to parse as Unix.
 	return parseLsListLine(fields[0]+" 1 "+scanner.Remaining(), now, loc)
+}
+
+// parseAS400ListLine parses the native LIST format used by IBM i (AS/400)
+// QTCP FTP servers, which none of the parsers above recognise, e.g.:
+//
+//	USERNAME            31 26/07/26 11:02:23 *STMF      EXAMPLE_FILE.xml
+//
+// Columns: owner, size, date (DD/MM/YY), time (HH:MM:SS), object type
+// (*STMF/*DIR/...), name. The object-type field is what distinguishes this
+// shape from every other format here, so it's used as the guard that keeps
+// this parser from ever matching another server's LIST output.
+func parseAS400ListLine(line string, _ time.Time, loc *time.Location) (*Entry, error) {
+	scanner := newScanner(line)
+	fields := scanner.NextFields(5)
+	if len(fields) < 5 {
+		return nil, errUnsupportedListLine
+	}
+
+	objType := fields[4]
+	if !strings.HasPrefix(objType, "*") {
+		return nil, errUnsupportedListLine
+	}
+
+	size, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return nil, errUnsupportedListLine
+	}
+
+	t, err := time.ParseInLocation("02/01/06 15:04:05", fields[2]+" "+fields[3], loc)
+	if err != nil {
+		return nil, errUnsupportedListLine
+	}
+
+	// Only a recognised stream file or directory is reported; any other
+	// object type (e.g. *SAVF, *MBR, *PGM) is conservatively rejected here
+	// rather than guessed at, so a caller that recurses into folders (e.g.
+	// Walker) never mistakes an unsupported object for a real directory.
+	var entryType EntryType
+	switch objType {
+	case "*STMF":
+		entryType = EntryTypeFile
+	case "*DIR":
+		entryType = EntryTypeFolder
+	default:
+		return nil, errUnsupportedListLine
+	}
+
+	return &Entry{
+		Name: strings.TrimLeft(scanner.Remaining(), " "),
+		Type: entryType,
+		Size: size,
+		Time: t,
+	}, nil
 }
 
 // parseListLine parses the various non-standard format returned by the LIST

--- a/parse_test.go
+++ b/parse_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -191,4 +192,63 @@ func newTime(year int, month time.Month, day int, hourMinSec ...int) time.Time {
 	}
 
 	return time.Date(year, month, day, hour, min, sec, 0, time.UTC)
+}
+
+// TestParseAS400ListLine pins support for IBM i (AS/400) QTCP FTP servers,
+// whose native LIST format none of the parsers above recognise.
+func TestParseAS400ListLine(t *testing.T) {
+	t.Run("a real AS/400 stream file line parses", func(t *testing.T) {
+		line := "USERNAME            31 26/07/26 11:02:23 *STMF      EXAMPLE_FILE.xml"
+
+		entry, err := parseAS400ListLine(line, time.Now(), time.UTC)
+		require.NoError(t, err)
+		require.Equal(t, "EXAMPLE_FILE.xml", entry.Name)
+		require.Equal(t, EntryTypeFile, entry.Type)
+		require.Equal(t, uint64(31), entry.Size)
+		require.Equal(t, time.Date(2026, time.July, 26, 11, 2, 23, 0, time.UTC), entry.Time)
+	})
+
+	t.Run("a directory parses as a folder", func(t *testing.T) {
+		line := "USERNAME            10 26/07/26 11:02:23 *DIR       SUBDIR"
+
+		entry, err := parseAS400ListLine(line, time.Now(), time.UTC)
+		require.NoError(t, err)
+		require.Equal(t, EntryTypeFolder, entry.Type)
+	})
+
+	t.Run("a filename containing spaces is preserved in full", func(t *testing.T) {
+		line := "USERNAME            31 26/07/26 11:02:23 *STMF      EXAMPLE PALLET DATA.xml"
+
+		entry, err := parseAS400ListLine(line, time.Now(), time.UTC)
+		require.NoError(t, err)
+		require.Equal(t, "EXAMPLE PALLET DATA.xml", entry.Name)
+	})
+
+	t.Run("an unrecognised object type is rejected, not guessed at", func(t *testing.T) {
+		line := "USERNAME            10 26/07/26 11:02:23 *SAVF      BACKUP"
+
+		_, err := parseAS400ListLine(line, time.Now(), time.UTC)
+		require.ErrorIs(t, err, errUnsupportedListLine)
+	})
+
+	t.Run("a Unix-style ls line is rejected, not misinterpreted", func(t *testing.T) {
+		line := "-rw-r--r--   1 owner group     1234 Jan 01 12:00 filename.txt"
+
+		_, err := parseAS400ListLine(line, time.Now(), time.UTC)
+		require.ErrorIs(t, err, errUnsupportedListLine)
+	})
+
+	t.Run("a short garbage line is rejected", func(t *testing.T) {
+		_, err := parseAS400ListLine("not enough fields here", time.Now(), time.UTC)
+		require.ErrorIs(t, err, errUnsupportedListLine)
+	})
+
+	t.Run("parseListLine dispatches to the AS/400 parser as a last resort", func(t *testing.T) {
+		line := "USERNAME            31 26/07/26 11:02:23 *STMF      EXAMPLE_FILE.xml"
+
+		entry, err := parseListLine(line, time.Now(), time.UTC)
+		require.NoError(t, err)
+		require.Equal(t, "EXAMPLE_FILE.xml", entry.Name)
+		require.Equal(t, uint64(31), entry.Size)
+	})
 }


### PR DESCRIPTION
## Summary
- Adds `parseAS400ListLine` to recognise the native `LIST` line format used by IBM i (AS/400) QTCP FTP servers - currently unrecognised by every existing parser, causing `List()` to silently return zero entries against these servers even on a successful listing.
- Appended last in `listLineParsers`, gated on the `*`-prefixed object-type marker unique to this format, so it can't misfire on any other server's output.
- Unrecognised object types (anything other than `*STMF`/`*DIR`) are rejected rather than guessed at, so a caller that recurses into folders (e.g. `Walker`) never mistakes an unsupported object for a real directory.

## Test plan
- [x] `go test ./...` - full existing suite plus new `TestParseAS400ListLine` subtests, all passing
- [x] `go vet ./...` clean